### PR TITLE
core crate: add serde derive feature

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 
 [dependencies]
 deps = { version = "0.1.0", path = "../deps" }
-serde = { version = "1.0.144" }
+serde = { version = "1.0.144", features = ["derive"] }
 
 [dev-dependencies]
 smoke = { version = "0.3" }


### PR DESCRIPTION
just a small detail, otherwise the crate doesn't compile by itself (but it does when compiled together)