### PR TITLE
byron workarounds

### DIFF
--- a/blockchain-source/Cargo.toml
+++ b/blockchain-source/Cargo.toml
@@ -16,7 +16,10 @@ serde = { version = "1.0.144" }
 thiserror = { version = "1.0" }
 
 cardano-net = "0.2.1"
-cardano-sdk = "0.2.4"
+cardano-sdk = "0.2.5"
 tokio = { version = "1", features = [ "full" ] }
 tracing = { version = "0.1" }
 cbored = "0.3.3"
+cbored-derive = "0.3.1"
+cryptoxide = "0.4.2"
+hex = "0.4.3"

--- a/blockchain-source/src/cardano/byron.rs
+++ b/blockchain-source/src/cardano/byron.rs
@@ -1,0 +1,134 @@
+//! The support in cardano-sdk for byron era block is a bit limited to the moment.
+//!
+//! This module fills some of those gaps. It should be removed once these these things are provided
+//! there.
+//!
+//! Most notably
+//!
+//! - There is no support for boundary headers.
+//! - The hashes for byron headers are computed incorrectly.
+//!
+//! This doesn't implement full support for the first point, we only parse what's needed to compute
+//! the hash, parent, height, and epoch-slot of epoch boundary blocks.
+use super::time::epoch_slot_to_absolute;
+use anyhow::Context;
+use cardano_sdk::chain::{
+    byron::{self, ChainDifficulty},
+    AnyCbor, HeaderHash,
+};
+use cbored::{CborDataOf, CborRepr};
+use cryptoxide::hashing::blake2b_256;
+use dcspark_core::{BlockNumber, SlotNumber};
+
+#[derive(Debug, Clone, CborRepr, PartialEq, Eq)]
+#[cborrepr(enumtype = "tagvariant")]
+pub enum ByronBlock {
+    ByronBoundary(Ebb),
+    Byron(BlockByron),
+}
+
+#[derive(Clone, Debug, CborRepr, PartialEq, Eq)]
+#[cborrepr(structure = "array")]
+pub struct Ebb {
+    pub header: CborDataOf<BoundaryHeader>,
+    pub body: AnyCbor,
+    pub extra: AnyCbor,
+}
+
+#[derive(Clone, Debug, CborRepr, PartialEq, Eq)]
+#[cborrepr(structure = "array")]
+pub struct BlockByron {
+    // CborDataOf keeps the data unserialized, which is important for hashing because the current
+    // representation of the byron::Header doesn't preserve the binary representation.
+    pub header: CborDataOf<byron::Header>,
+    pub body: AnyCbor,
+    pub extra: AnyCbor,
+}
+
+#[derive(Debug, Clone, CborRepr, PartialEq, Eq)]
+#[cborrepr(structure = "array")]
+pub struct BoundaryHeader {
+    pub protocol_magic: u64,
+    pub previous_hash: HeaderHash,
+    pub body_proof: AnyCbor,
+    pub consensus: ConsensusBoundary,
+    pub extra_data: AnyCbor,
+}
+
+#[derive(Debug, Clone, CborRepr, PartialEq, Eq)]
+#[cborrepr(structure = "array")]
+pub struct ConsensusBoundary {
+    pub epoch: u64,
+    pub chain_difficulty: ChainDifficulty,
+}
+
+pub enum ByronHeader {
+    ByronBoundary(BoundaryHeader),
+    Byron(Box<byron::Header>),
+}
+
+impl ByronBlock {
+    pub(super) fn is_boundary(&self) -> bool {
+        matches!(self, ByronBlock::ByronBoundary(_))
+    }
+
+    pub(super) fn decode(bytes: &[u8]) -> anyhow::Result<Self> {
+        cbored::decode_from_bytes(bytes).context("couldn't decode byron block")
+    }
+
+    // cardano-sdk has a hash method for the byron header, but it's missing the prefix.
+    //
+    // it also doesn't support the epoch boundary header.
+    pub(super) fn hash(&self) -> HeaderHash {
+        let with_tag = match self {
+            // ref: https://input-output-hk.github.io/ouroboros-network/cardano-ledger/src/Cardano.Chain.Block.Header.html#wrapBoundaryBytes
+            ByronBlock::ByronBoundary(ebb) => [&[0x82, 0x00], ebb.header.as_ref()].concat(),
+            // ref: https://input-output-hk.github.io/ouroboros-network/cardano-ledger/src/Cardano.Chain.Block.Header.html#wrapHeaderBytes
+            ByronBlock::Byron(byron) => [&[0x82, 0x01], byron.header.as_ref()].concat(),
+        };
+
+        HeaderHash(blake2b_256(&with_tag))
+    }
+
+    pub(super) fn header(&self) -> ByronHeader {
+        match self {
+            ByronBlock::ByronBoundary(ebb) => ByronHeader::ByronBoundary(ebb.header.unserialize()),
+            ByronBlock::Byron(byron) => ByronHeader::Byron(Box::new(byron.header.unserialize())),
+        }
+    }
+}
+
+impl ByronHeader {
+    pub(super) fn previous_hash(&self) -> HeaderHash {
+        match self {
+            ByronHeader::ByronBoundary(header) => header.previous_hash.clone(),
+            ByronHeader::Byron(header) => header.previous_hash.clone(),
+        }
+    }
+
+    pub(super) fn block_number(&self) -> BlockNumber {
+        BlockNumber::new(match self {
+            ByronHeader::ByronBoundary(header) => header.consensus.chain_difficulty.0,
+            ByronHeader::Byron(header) => header.consensus.chain_difficulty.0,
+        })
+    }
+
+    pub(super) fn slot_number(&self) -> SlotNumber {
+        SlotNumber::new(match self {
+            ByronHeader::ByronBoundary(header) => epoch_slot_to_absolute(header.consensus.epoch, 0),
+            ByronHeader::Byron(header) => {
+                let slot = header.consensus.slot_id.slot_id.into();
+                let epoch = header.consensus.slot_id.epoch;
+
+                epoch_slot_to_absolute(epoch, slot)
+            }
+        })
+    }
+
+    pub(super) fn epoch(&self) -> u64 {
+        match self {
+            ByronHeader::ByronBoundary(header) => header.consensus.epoch,
+            ByronHeader::Byron(header) => header.consensus.slot_id.epoch,
+        }
+    }
+}

--- a/blockchain-source/src/cardano/configuration.rs
+++ b/blockchain-source/src/cardano/configuration.rs
@@ -1,4 +1,4 @@
-use super::Point;
+use super::{time::Era, Point};
 use cardano_sdk::protocol::Magic;
 use dcspark_core::{BlockId, SlotNumber};
 use std::borrow::Cow;
@@ -8,6 +8,9 @@ pub struct NetworkConfiguration {
     pub chain_info: ChainInfo,
     pub relay: (Cow<'static, str>, u16),
     pub from: Point,
+    pub genesis_parent: BlockId,
+    pub genesis: BlockId,
+    pub shelley_era_config: Era,
 }
 
 #[derive(Clone, Debug, serde::Deserialize)]
@@ -51,6 +54,13 @@ impl NetworkConfiguration {
                     "aa83acbf5904c0edfe4d79b3689d3d00fcfc553cf360fd2229b98d464c28e9de",
                 ),
             },
+            genesis_parent: BlockId::new(
+                "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb",
+            ),
+            genesis: BlockId::new(
+                "89d9b5a5b8ddc8d7e5a6795e9774d97faf1efea59b2caf7eaf9f8c5b32059df4",
+            ),
+            shelley_era_config: Era::SHELLEY_MAINNET,
         }
     }
 
@@ -64,6 +74,13 @@ impl NetworkConfiguration {
                     "c4a1595c5cc7a31eda9e544986fe9387af4e3491afe0ca9a80714f01951bbd5c",
                 ),
             },
+            genesis_parent: BlockId::new(
+                "d4b8de7a11d929a323373cbab6c1a9bdc931beffff11db111cf9d57356ee1937",
+            ),
+            genesis: BlockId::new(
+                "9ad7ff320c9cf74e0f5ee78d22a85ce42bb0a487d0506bf60cfb5a91ea4497d2",
+            ),
+            shelley_era_config: Era::SHELLEY_PREPROD,
         }
     }
 
@@ -77,6 +94,13 @@ impl NetworkConfiguration {
                     "8542d7f0b744f40f3de6164294b5feb0095307d46c7290acc8a5d9bd802acb8e",
                 ),
             },
+            genesis_parent: BlockId::new(
+                "72593f260b66f26bef4fc50b38a8f24d3d3633ad2e854eaf73039eb9402706f1",
+            ),
+            genesis: BlockId::new(
+                "268ae601af8f9214804735910a3301881fbe0eec9936db7d1fb9fc39e93d1e37",
+            ),
+            shelley_era_config: Era::SHELLEY_PREVIEW,
         }
     }
 }

--- a/blockchain-source/src/cardano/event.rs
+++ b/blockchain-source/src/cardano/event.rs
@@ -153,8 +153,9 @@ impl BlockEvent {
             .context("failed to deserialize block");
 
         if let Ok(block) = block {
-            let id = BlockId::new(block.header().hash().to_string());
-            let block_number = BlockNumber::new(block.header().block_number());
+            let header = block.header();
+            let id = BlockId::new(header.hash().to_string());
+            let block_number = BlockNumber::new(header.block_number());
 
             let parent_id = get_parent_id(&block.header());
 
@@ -163,7 +164,7 @@ impl BlockEvent {
                 id,
                 parent_id,
                 block_number,
-                slot_number: SlotNumber::new(block.header().slot()),
+                slot_number: SlotNumber::new(header.slot()),
                 is_boundary_block: false,
                 // this is not in the header, and computing it requires knowing the network
                 // details, which makes implementing `Serialize` and `Deserialize`more complicated,

--- a/blockchain-source/src/cardano/mod.rs
+++ b/blockchain-source/src/cardano/mod.rs
@@ -1,6 +1,8 @@
+mod byron;
 mod configuration;
 mod event;
 mod point;
+pub mod time;
 
 pub use self::event::{BlockEvent, CardanoNetworkEvent};
 use crate::Source;
@@ -9,12 +11,11 @@ use cardano_net::{NetworkDescription, NetworkHandle};
 pub use cardano_sdk::protocol::Tip;
 use cardano_sdk::protocol::Version;
 pub use configuration::{ChainInfo, NetworkConfiguration};
-use dcspark_core::{BlockId, BlockNumber, SlotNumber};
-use event::get_parent_id;
+use dcspark_core::BlockId;
 pub use point::*;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::{interval, Duration, MissedTickBehavior};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, warn, Instrument};
 
 const TX_PROCESSING_CHANNEL_BOUND: usize = 1000;
 
@@ -48,6 +49,7 @@ impl Source for CardanoSource {
     /// * None of the points provided in from are in the current branch.
     /// * One of the points provided is the current tip.
     ///
+    #[tracing::instrument(skip(self))]
     async fn pull(&mut self, from: &Self::From) -> Result<Option<Self::Event>> {
         // If there is a request in flight, then we try to get one of those blocks.
         //
@@ -66,8 +68,6 @@ impl Source for CardanoSource {
         //      * The previous one just ended (`next` was None)
         //
         // Then, we enqueue a new fetch from `from` to the current tip, and block on that.
-
-        debug!("starting new request");
 
         let (tx, rx) = mpsc::channel(TX_PROCESSING_CHANNEL_BOUND);
 
@@ -111,7 +111,18 @@ impl CardanoSource {
 
         // we don't need the handle, since we can signalkill the task by just dropping the request
         // channel, and the task can't error.
-        let _ = tokio::task::spawn(request_handler(handle, rx, exit_tx, tip_update_pace));
+        let _ = tokio::task::spawn(
+            request_handler(
+                handle,
+                rx,
+                exit_tx,
+                tip_update_pace,
+                network_config.genesis_parent.clone(),
+                network_config.genesis.clone(),
+                config,
+            )
+            .instrument(tracing::info_span!("request handler")),
+        );
 
         Ok(Self {
             service: tx,
@@ -144,6 +155,9 @@ async fn request_handler(
     mut requests: mpsc::Receiver<(Vec<Point>, mpsc::Sender<Result<Event>>)>,
     exit_signal: oneshot::Sender<()>,
     tip_update_pace: Duration,
+    genesis_parent: BlockId,
+    genesis: BlockId,
+    config: NetworkDescription,
 ) {
     let mut interval = interval(tip_update_pace);
     interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
@@ -151,12 +165,41 @@ async fn request_handler(
     while let Some((from, channel)) = requests.recv().await {
         interval.tick().await;
 
+        let from = if from
+            == vec![Point::BlockHeader {
+                slot_nb: 0.into(),
+                hash: genesis_parent.clone(),
+            }] {
+            vec![Point::BlockHeader {
+                hash: genesis.clone(),
+                slot_nb: 0.into(),
+            }]
+        } else {
+            from
+        };
+
         if let Err(e) = block_fetch(&mut handle, from, &channel).await {
-            let _ = channel.send(Err(e));
+            warn!(error = %e, "failed to start block_fetch");
+            handle.stop().await;
+
+            info!("trying to reestablish connection with the node");
+
+            match NetworkHandle::start(&config).await {
+                Ok(new_handle) => {
+                    info!("connection reestablished succesfully");
+                    handle = new_handle
+                }
+                Err(error) => {
+                    error!(%error, "failed to reestablish connection with the node");
+
+                    let _ = channel.send(Err(e));
+
+                    break;
+                }
+            }
         }
     }
 
-    handle.stop().await;
     let _ = exit_signal.send(());
 }
 
@@ -171,6 +214,10 @@ async fn block_fetch(
         .map(cardano_sdk::protocol::Point::try_from)
         .collect();
 
+    if points.is_err() {
+        error!("invalid point found, this shouldn't happen");
+    }
+
     let mut points = points?;
 
     points.sort_by_key(|b: &cardano_sdk::protocol::Point| std::cmp::Reverse(b.slot_nb()));
@@ -178,7 +225,10 @@ async fn block_fetch(
     debug!("sending intersection request");
 
     let (from, tip) = match handle.chainsync.intersect(points).await? {
-        cardano_net::ChainIntersection::Found(from, tip) => (from, tip),
+        cardano_net::ChainIntersection::Found(from, tip) => {
+            info!(%from, %tip, "intersection found");
+            (from, tip)
+        }
         cardano_net::ChainIntersection::NotFound(tip) => {
             // this would cause `pull` to return None, which the 'puller' could potentially use as
             // a signal to change update the from argument the next time.
@@ -204,7 +254,10 @@ async fn block_fetch(
 
     let mut block_fetcher = match handle.blockfetch.request_range(from, tip.point).await? {
         Some(block_fetcher) => block_fetcher,
-        None => return Ok(()),
+        None => {
+            debug!("no blocks found in range");
+            return Ok(());
+        }
     };
 
     // the from in request_range is inclusive, but the from in `pull` is not supposed to be
@@ -212,29 +265,18 @@ async fn block_fetch(
     let _ = block_fetcher.next().await?;
 
     while let Some(raw_block) = block_fetcher.next().await? {
-        let block = raw_block
-            .unserialize()
-            .context("failed to deserialize block");
+        let event = BlockEvent::from_serialized_block(raw_block);
 
-        let block = block.map(|block| {
-            let id = BlockId::new(block.header().hash().to_string());
-            let block_number = BlockNumber::new(block.header().block_number());
-
-            let parent_id = get_parent_id(&block.header());
-
-            CardanoNetworkEvent::Block(BlockEvent {
-                raw_block,
-                id,
-                parent_id,
-                block_number,
-                slot_number: SlotNumber::new(block.header().slot()),
-            })
-        });
-
-        if channel.send(block).await.is_err() {
-            debug!("request response channel was closed, ignoring received blocks");
+        if channel
+            .send(event.map(CardanoNetworkEvent::Block))
+            .await
+            .is_err()
+        {
+            warn!("request response channel was closed, ignoring received blocks");
         }
     }
+
+    debug!("block range request finished succesfully");
 
     Ok(())
 }

--- a/blockchain-source/src/cardano/point.rs
+++ b/blockchain-source/src/cardano/point.rs
@@ -1,7 +1,7 @@
 use anyhow::anyhow;
 use dcspark_core::{BlockId, SlotNumber};
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Hash)]
 pub enum Point {
     Origin,
     BlockHeader { slot_nb: SlotNumber, hash: BlockId },

--- a/blockchain-source/src/cardano/time.rs
+++ b/blockchain-source/src/cardano/time.rs
@@ -1,0 +1,71 @@
+const EPOCH_LENGTH_IN_SECONDS: u64 = 43200;
+const BYRON_SLOT_DURATION: u64 = 20;
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct Era {
+    pub first_slot: u64,
+    pub start_epoch: u64,
+    pub known_time: u64,
+    pub slot_length: u64,
+}
+
+impl Era {
+    pub const SHELLEY_MAINNET: Self = Self {
+        first_slot: 4492800,
+        start_epoch: 208,
+        known_time: 1596059091,
+        slot_length: 1,
+    };
+
+    pub const SHELLEY_PREPROD: Self = Self {
+        first_slot: 86400,
+        start_epoch: 0,
+        known_time: 1655769600,
+        slot_length: 1,
+    };
+
+    pub const SHELLEY_PREVIEW: Self = Self {
+        first_slot: 0,
+        start_epoch: 0,
+        known_time: 1660003200,
+        slot_length: 1,
+    };
+
+    pub const fn compute_timestamp(&self, slot: u64) -> u64 {
+        self.known_time + (slot - self.first_slot) * self.slot_length
+    }
+
+    pub fn absolute_slot_to_epoch(&self, slot: u64) -> Option<u64> {
+        slot.checked_sub(self.first_slot)
+            .map(|slot_relative_to_era| {
+                self.start_epoch + slot_relative_to_era / EPOCH_LENGTH_IN_SECONDS
+            })
+    }
+}
+
+pub const fn epoch_slot_to_absolute(epoch: u64, epoch_slot: u64) -> u64 {
+    let slots_per_epoch = EPOCH_LENGTH_IN_SECONDS / BYRON_SLOT_DURATION;
+    epoch * slots_per_epoch + epoch_slot
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn absolute_slot_to_epoch() {
+        let era = Era::SHELLEY_MAINNET;
+
+        assert_eq!(None, era.absolute_slot_to_epoch(4492800 - 1));
+        assert_eq!(Some(208), era.absolute_slot_to_epoch(4492800));
+        assert_eq!(Some(208), era.absolute_slot_to_epoch(4492840));
+        assert_eq!(
+            Some(208),
+            era.absolute_slot_to_epoch(era.first_slot + EPOCH_LENGTH_IN_SECONDS - 1)
+        );
+        assert_eq!(
+            Some(209),
+            era.absolute_slot_to_epoch(era.first_slot + EPOCH_LENGTH_IN_SECONDS)
+        );
+    }
+}

--- a/blockchain-source/src/multiverse/mod.rs
+++ b/blockchain-source/src/multiverse/mod.rs
@@ -168,7 +168,12 @@ where
 
         let new_stable_position = selected.map(|entry_ref| entry_ref.inner().clone());
 
-        if let Some(stable) = new_stable_position {
+        if let Some(stable) = new_stable_position.filter(|stable| {
+            self.confirmed
+                .as_ref()
+                .map(|confirmed| stable != confirmed)
+                .unwrap_or(true)
+        }) {
             let block = self
                 .multiverse
                 .get(&stable)

--- a/blockchain-source/src/multiverse/rollback.rs
+++ b/blockchain-source/src/multiverse/rollback.rs
@@ -1,0 +1,331 @@
+use crate::{multiverse::multiverse_insert_and_gc, EventObject, GetNextFrom, PullFrom, Source};
+use anyhow::{anyhow, Result};
+use multiverse::{BestBlock, BestBlockSelectionRule, Variant};
+use serde::{de::DeserializeOwned, Serialize};
+use std::{
+    collections::HashSet,
+    fmt::{Debug, Display},
+    hash::Hash,
+};
+
+#[derive(Debug)]
+pub enum Event<Inner, EventId> {
+    InnerEvent(Inner),
+    Rollback(EventId),
+}
+
+/// Source that provides the tips + confirmed point to the cardano source when pulling, and also
+/// detects rollbacks by keeping track of the last seen block. If a block is received from the
+/// inner source that is not a direct succesor to the previous one, this source generates a
+/// rollback event to the common ancestor with the previous branch.
+pub struct ForkHandlingSource<K, V, InnerSource, Event> {
+    multiverse: multiverse::Multiverse<K, V>,
+    source: InnerSource,
+    confirmation_depth: usize,
+    confirmed: Option<K>,
+    last: Option<K>,
+    events: Vec<Event>,
+}
+
+impl<K, V, InnerSource, E> ForkHandlingSource<K, V, InnerSource, E> {
+    pub fn new(
+        multiverse: multiverse::Multiverse<K, V>,
+        confirmation_depth: usize,
+        inner_source: InnerSource,
+    ) -> Self
+    where
+        K: AsRef<[u8]> + Eq + Hash + Debug + Clone + Sync,
+        V: Variant<Key = K>,
+    {
+        let BestBlock {
+            selected,
+            discarded: _,
+        } = {
+            let _span =
+                tracing::span!(tracing::Level::INFO, "selecting best root options").entered();
+            multiverse.select_best_block(BestBlockSelectionRule::LongestChain {
+                depth: confirmation_depth,
+                // not going to delete anything here, so this doesn't matter
+                age_gap: 0,
+            })
+        };
+
+        let last = multiverse.iter().last().map(|entry| entry.id().clone());
+
+        Self {
+            multiverse,
+            confirmation_depth,
+            source: inner_source,
+            confirmed: selected.map(|k| k.inner().clone()),
+            last,
+            events: Default::default(),
+        }
+    }
+
+    pub fn into_inner(self) -> InnerSource {
+        self.source
+    }
+}
+
+#[async_trait::async_trait]
+impl<K, V, InnerSource, ScalarInnerFrom> Source
+    for ForkHandlingSource<K, V, InnerSource, Event<InnerSource::Event, ScalarInnerFrom>>
+where
+    InnerSource: Source<Event = V, From = Vec<ScalarInnerFrom>> + Send,
+    ScalarInnerFrom: PullFrom + PartialEq + Clone + Sync + std::fmt::Debug + Eq + Hash,
+    K: AsRef<[u8]>
+        + Eq
+        + Hash
+        + Debug
+        + Clone
+        + Display
+        + PullFrom
+        + Sync
+        + Serialize
+        + DeserializeOwned,
+    InnerSource::Event: GetNextFrom<From = ScalarInnerFrom>,
+    InnerSource::Event: Variant<Key = K> + Clone + EventObject,
+    V: Variant<Key = K> + Clone + EventObject + Debug,
+    V: GetNextFrom<From = ScalarInnerFrom>,
+{
+    type Event = Event<InnerSource::Event, ScalarInnerFrom>;
+    type From = Option<ScalarInnerFrom>;
+
+    #[tracing::instrument(skip(self), fields(self.confirmed = ?self.confirmed))]
+    async fn pull(&mut self, from: &Self::From) -> Result<Option<Self::Event>> {
+        if let Some(event) = self.events.pop() {
+            return Ok(Some(event));
+        }
+
+        let inner_from = {
+            let mut checkpoints = HashSet::new();
+
+            for k in self.multiverse.tips().iter() {
+                let v = self
+                    .multiverse
+                    .get(k)
+                    .ok_or_else(|| anyhow!("tip doesn't have an entry in the multiverse"))?
+                    .next_from()
+                    .unwrap()
+                    .clone();
+
+                checkpoints.insert(v);
+            }
+
+            if let Some(confirmed) = &self.confirmed {
+                let confirmed = self.multiverse.get(confirmed).unwrap();
+
+                checkpoints.insert(confirmed.next_from().unwrap());
+            }
+
+            if let Some(from) = from {
+                checkpoints.insert(from.clone());
+            }
+
+            checkpoints.into_iter().collect()
+        };
+
+        let block = match self.source.pull(&inner_from).await? {
+            Some(block) => {
+                if block.is_blockchain_tip() {
+                    return Ok(Some(Event::InnerEvent(block)));
+                }
+
+                if self.multiverse.get(block.id()).is_some() {
+                    return Ok(None);
+                } else {
+                    block
+                }
+            }
+            None => return Ok(None),
+        };
+
+        let parent_id = block.parent_id().clone();
+        let block_id = block.id().clone();
+
+        let new_stable_position =
+            multiverse_insert_and_gc(block.clone(), &mut self.multiverse, self.confirmation_depth)?;
+
+        if let Some(stable) = new_stable_position.filter(|stable| {
+            self.confirmed
+                .as_ref()
+                .map(|confirmed| stable != confirmed)
+                .unwrap_or(true)
+        }) {
+            self.confirmed.replace(stable);
+        }
+
+        let previous_tip = self.last.replace(block_id.clone());
+
+        let new_event = if previous_tip
+            .as_ref()
+            // if the blocks are contiguous, we are always in the same branch
+            .map(|last| last == &parent_id)
+            .unwrap_or(false)
+        {
+            Event::InnerEvent(block)
+        } else if let Some(mut previous_branch_cursor) = previous_tip {
+            // algorithm:
+            //
+            // Traverse the previous branch backwards, building a hashset with all the hashes in
+            // the way. This should stop at the confirmed block.
+            //
+            // Traverse the new branch backwards. For each block check if it was in the previous
+            // branch.
+            //
+            // If it is not, then we push it on the stack. Because we are traversing backwards, the
+            // top of the stack is the block with less height in the chain.
+            //
+            // If it is, we push a rollback event to this block on the stack.
+            //
+            // Then events are popped until the stack is empty.
+            let mut blocks_in_previous_branch = HashSet::new();
+
+            while let Some(entry) = self.multiverse.get(&previous_branch_cursor) {
+                blocks_in_previous_branch.insert(entry.id());
+                previous_branch_cursor = entry.parent_id().clone();
+            }
+
+            let mut current_branch_cursor = block_id;
+
+            while let Some(entry) = self.multiverse.get(&current_branch_cursor) {
+                if blocks_in_previous_branch.contains(entry.id()) {
+                    self.events
+                        .push(Event::Rollback(entry.next_from().unwrap()));
+                    break;
+                }
+
+                self.events.push(Event::InnerEvent(entry.clone()));
+                current_branch_cursor = entry.parent_id().clone();
+            }
+
+            // this will always be a rollback event.
+            //
+            // if it's empty, it probably means the confirmation depth is not big enough, in which
+            // case there is nothing to do.
+            //
+            // we could return an error though.
+            self.events
+                .pop()
+                .expect("no common ancestor between branches")
+        } else {
+            // if the db is empty, send a rollback event to the `from` argument, just to be
+            // safe
+            self.events.push(Event::InnerEvent(block));
+            Event::Rollback(from.as_ref().unwrap().clone())
+        };
+
+        Ok(Some(new_event))
+    }
+}
+
+impl<Inner: EventObject, EventId: Send> EventObject for Event<Inner, EventId> {
+    fn is_blockchain_tip(&self) -> bool {
+        if let Self::InnerEvent(e) = self {
+            e.is_blockchain_tip()
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::multiverse::tests::{K, V};
+    use crate::Source;
+    use anyhow::Result;
+    use dcspark_core::BlockNumber;
+
+    #[derive(Default, Debug)]
+    struct TestSource {
+        sorted: Vec<V>,
+        last: usize,
+    }
+
+    impl TestSource {
+        fn extend(&mut self, _parent: K, v: V) {
+            self.sorted.push(v);
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Source for TestSource {
+        type Event = V;
+        type From = Vec<K>;
+
+        async fn pull(&mut self, _from: &Self::From) -> Result<Option<Self::Event>> {
+            let result = self.sorted.get(self.last);
+            self.last += 1;
+
+            Ok(result.cloned())
+        }
+    }
+
+    fn add_fork(source: &mut TestSource, length: usize, forking_point: usize) {
+        let first_id = source.sorted.len();
+
+        let from = first_id;
+        let to = first_id + length - forking_point;
+
+        for i in from..=to {
+            let parent_id = if i == from { forking_point } else { i - 1 };
+
+            let parent_id = K(format!("s{0}", parent_id));
+
+            source.extend(
+                parent_id.clone(),
+                V {
+                    id: K(format!("s{0}", i)),
+                    parent_id,
+                    block_number: BlockNumber::new((i - forking_point) as u64),
+                },
+            )
+        }
+    }
+
+    // this generates a DAG with 3 branches of a certain length (from tip to s0)
+    //
+    // The source will first return the central branch entirely.
+    //
+    // Then it will return the other branches, each one in its entirety.
+    //
+    // This would lead to the rollback source generating 2 rollback events.
+    fn forking_chain(length: usize) -> TestSource {
+        let mut source = TestSource::default();
+
+        add_fork(&mut source, length, 0);
+        add_fork(&mut source, length, 3);
+        add_fork(&mut source, length, 4);
+
+        source
+    }
+
+    #[tokio::test]
+    async fn generates_rollback_event() {
+        let min_depth = 3;
+
+        let source = forking_chain(6);
+
+        let mut multiverse: ForkHandlingSource<K, V, TestSource, Event<V, K>> =
+            ForkHandlingSource::new(
+                multiverse::Multiverse::temporary().unwrap(),
+                min_depth,
+                source,
+            );
+
+        let mut parent = K("s0".to_string());
+
+        while let Some(event) = multiverse.pull(&Some(K("s0".to_string()))).await.unwrap() {
+            match event {
+                Event::InnerEvent(event) => {
+                    assert_eq!(event.parent_id(), &parent);
+                    parent = event.id().clone();
+                }
+                Event::Rollback(new_parent) => {
+                    parent = new_parent.clone();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds support for bootstrapping the cardano net source from byron's genesis.

There are currently three limitations with the library that need to be worked around.

- We don't have the rest of the chainsync mini protocol. This means we can't do `(from, to]` requests, which means we can't start from the genesis data hash, because what's provided to the block range requests need to be blocks in the chain. The work around here is to hardcode the hash of those blocks, so we can start from there.
- There is no support for parsing boundary blocks in cardano-sdk. Although we don't really need to parse those, it will break the multiverse chain if we skipped those, since we need the ids for the parent relation. This handles that case, by adding the partial format that we need.
- The hashes for byron blocks are incorrectly computed right now, so this PR also adds that part custom.

Most of these workarounds should be removed eventually.

Also, handle the case when there is an error in the connection, by restarting it (although only once per error, there is no reconnection loop)

Besides, add code to correctly compute the absolute slot for byron blocks. It's needed for the protocol, but it's not part of the header itself. Also to compute the epoch for shelley blocks, since it's needed as a field in carp.