### PR TITLE
Remove beta and old test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,8 +9,6 @@ jobs:
       matrix:
         rust:
           - stable
-          - beta
-          - 1.57.0  # Minimum supported rust version
 
     steps:
       - name: "Checkout"

--- a/fraos/src/growable_mmap.rs
+++ b/fraos/src/growable_mmap.rs
@@ -268,7 +268,6 @@ impl GrowableMmap {
             None => add,
             Some(_) => {
                 let active_mmap = active_mmap_size.unwrap_or(2048);
-                #[allow(clippy::manual_clamp)]
                 max(add, min(active_mmap * 2, 4096 * 4096))
             }
         }


### PR DESCRIPTION
The workaround @ecioppettini proposed doesn't compile on rust 1.64, which is still supported option. I suggest we just remove beta and old rust version and focus on stable