### PR TITLE
implement source for option t

### DIFF
--- a/blockchain-source/src/source.rs
+++ b/blockchain-source/src/source.rs
@@ -62,6 +62,17 @@ impl PullFrom for BlockNumber {}
 impl PullFrom for BlockId {}
 impl PullFrom for TransactionId {}
 impl PullFrom for Point {}
+impl PullFrom for () {}
 
 impl<T: PullFrom> PullFrom for Vec<T> {}
 impl<T: PullFrom> PullFrom for Option<T> {}
+
+#[async_trait]
+impl<T: EventObject> Source for Option<T> {
+    type Event = T;
+    type From = ();
+
+    async fn pull(&mut self, _from: &Self::From) -> Result<Option<Self::Event>> {
+        Ok(self.take())
+    }
+}


### PR DESCRIPTION
Fixes compatibility issues regarding: https://github.com/dcSpark/milkomeda-validator/pull/1440 after merging https://github.com/dcSpark/milkomeda-validator/pull/1424