### PR TITLE
fix the BlockEvent deserialization

### DIFF
--- a/blockchain-source/src/cardano/event.rs
+++ b/blockchain-source/src/cardano/event.rs
@@ -1,9 +1,6 @@
 use crate::{EventObject, GetNextFrom};
 use anyhow::Context;
-use cardano_sdk::protocol::SerializedBlock;
-use cbored::Encode;
 use dcspark_core::{BlockId, BlockNumber, SlotNumber};
-use serde::de::Visitor;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum CardanoNetworkEvent<Block, Tip> {
@@ -18,12 +15,12 @@ impl<Block: Send, Tip: Send> EventObject for CardanoNetworkEvent<Block, Tip> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
 pub struct BlockEvent {
     pub id: BlockId,
     pub parent_id: BlockId,
     pub block_number: BlockNumber,
-    pub raw_block: SerializedBlock,
+    pub raw_block: Vec<u8>,
     pub slot_number: SlotNumber,
     pub is_boundary_block: bool,
     pub epoch: Option<u64>,
@@ -49,63 +46,6 @@ impl<Block, Tip> CardanoNetworkEvent<Block, Tip> {
             CardanoNetworkEvent::Tip(tip) => f(tip).map(CardanoNetworkEvent::Tip),
         }
     }
-}
-
-impl serde::Serialize for BlockEvent {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut writer = cbored::Writer::new();
-        self.raw_block.encode(&mut writer);
-        serializer.serialize_bytes(&writer.finalize())
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for BlockEvent {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        struct V;
-
-        impl<'de> Visitor<'de> for V {
-            type Value = BlockEvent;
-
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-                formatter.write_str("a byte array")
-            }
-
-            fn visit_bytes<E>(self, buf: &[u8]) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                decode_deserialized_block(buf).map_err(serde::de::Error::custom)
-            }
-
-            fn visit_seq<A: serde::de::SeqAccess<'de>>(
-                self,
-                mut seq: A,
-            ) -> Result<Self::Value, A::Error> {
-                let mut buf: Vec<u8> = Vec::with_capacity(seq.size_hint().unwrap_or(0));
-                while let Some(byte) = seq.next_element()? {
-                    buf.push(byte);
-                }
-
-                decode_deserialized_block(&buf).map_err(serde::de::Error::custom)
-            }
-        }
-
-        deserializer.deserialize_bytes(V)
-    }
-}
-
-fn decode_deserialized_block(buf: &[u8]) -> anyhow::Result<BlockEvent> {
-    let mut reader = cbored::Reader::new(buf);
-
-    let raw_block: SerializedBlock = reader.decode().context("invalid block")?;
-
-    BlockEvent::from_serialized_block(raw_block)
 }
 
 pub(crate) fn get_parent_id(header: &cardano_sdk::chain::Header) -> BlockId {
@@ -163,10 +103,9 @@ impl<Tip> GetNextFrom for CardanoNetworkEvent<BlockEvent, Tip> {
 }
 
 impl BlockEvent {
-    pub(crate) fn from_serialized_block(raw_block: SerializedBlock) -> anyhow::Result<Self> {
-        let block = raw_block
-            .unserialize()
-            .context("failed to deserialize block");
+    pub(crate) fn from_serialized_block(raw_block: &[u8]) -> anyhow::Result<Self> {
+        let block: anyhow::Result<cardano_sdk::chain::Block> =
+            cbored::decode_from_bytes(raw_block).context("failed to deserialize block");
 
         if let Ok(block) = block {
             let header = block.header();
@@ -176,7 +115,7 @@ impl BlockEvent {
             let parent_id = get_parent_id(&block.header());
 
             Ok(BlockEvent {
-                raw_block,
+                raw_block: raw_block.to_vec(),
                 id,
                 parent_id,
                 block_number,
@@ -188,10 +127,10 @@ impl BlockEvent {
                 // it can be computed later inside carp, since we don't need this in the bridge.
                 epoch: None,
             })
-        } else if let Ok(block) = crate::cardano::byron::ByronBlock::decode(raw_block.as_ref()) {
+        } else if let Ok(block) = crate::cardano::byron::ByronBlock::decode(raw_block) {
             let header = block.header();
             let event = BlockEvent {
-                raw_block,
+                raw_block: raw_block.to_vec(),
                 id: BlockId::new(block.hash().to_string()),
                 parent_id: BlockId::new(header.previous_hash().to_string()),
                 block_number: header.block_number(),
@@ -203,7 +142,7 @@ impl BlockEvent {
             Ok(event)
         } else {
             tracing::error!(
-                block = hex::encode(raw_block.as_ref()),
+                block = hex::encode(raw_block),
                 "failed to deserialize block"
             );
             block.map(|_| unreachable! {})

--- a/blockchain-source/src/cardano/mod.rs
+++ b/blockchain-source/src/cardano/mod.rs
@@ -265,7 +265,7 @@ async fn block_fetch(
     let _ = block_fetcher.next().await?;
 
     while let Some(raw_block) = block_fetcher.next().await? {
-        let event = BlockEvent::from_serialized_block(raw_block);
+        let event = BlockEvent::from_serialized_block(raw_block.as_ref());
 
         if channel
             .send(event.map(CardanoNetworkEvent::Block))


### PR DESCRIPTION
The serialization function is currently incorrect, since the `Decode` in `SerializedBlock` expects a cbor tag to be there, but it's not part of the buffer itself. It's only included when calling `Encode`. Since `SerializedBlock` doesn't have a public constructor, this is the more direct way.

Also, for some reason `serde_json` seems to be calling `visit_seq` instead of `visit_bytes`, so I added that method to the visitor. 

We will probably remove the storage from the multiverse later, but in the meantime, this prevents restarting.