### PR TITLE
BlockVasil: skip deserialization of tx_witnesses field

### DIFF
--- a/blockchain-source/src/cardano/block.rs
+++ b/blockchain-source/src/cardano/block.rs
@@ -1,13 +1,41 @@
 use cardano_sdk::chain::{
-    AnyCbor, BlockAlonzo, BlockShelley, Header, HeaderVasil, MetadataSet, TransactionBodies,
-    TxIndexes,
+    AnyCbor, Header, HeaderShelley, HeaderVasil, MetadataSet, TransactionBodies, TxIndexes,
 };
 use cbored::{CborRepr, DecodeError};
+
+// Currently, cardano-sdk can't parse blocks that have Redeemer fields inside the witnesses,
+// because of an issue deserializing the data field.
+//
+// Because for our use-cases these fields are not necessary anyway, we can just avoid the
+// validation by parsing them as `AnyCbor`
+//
+// Unfortunately the only way of doing that easily (without patching the library) is to just
+// re-define the block types here, this involves some code duplication, although it also gives us
+// better control.
 
 #[derive(Clone, Debug, CborRepr, PartialEq, Eq)]
 #[cborrepr(structure = "array")]
 pub struct BlockVasil {
     pub header: HeaderVasil,
+    pub tx_bodies: TransactionBodies,
+    pub tx_witnesses: AnyCbor,
+    pub metadata_set: MetadataSet,
+    pub invalid_tx: TxIndexes,
+}
+
+#[derive(Clone, Debug, CborRepr, PartialEq, Eq)]
+#[cborrepr(structure = "array")]
+pub struct BlockShelley {
+    pub header: HeaderShelley,
+    pub tx_bodies: TransactionBodies,
+    pub tx_witnesses: AnyCbor,
+    pub metadata_set: MetadataSet,
+}
+
+#[derive(Clone, Debug, CborRepr, PartialEq, Eq)]
+#[cborrepr(structure = "array")]
+pub struct BlockAlonzo {
+    pub header: HeaderShelley,
     pub tx_bodies: TransactionBodies,
     pub tx_witnesses: AnyCbor,
     pub metadata_set: MetadataSet,

--- a/blockchain-source/src/cardano/block.rs
+++ b/blockchain-source/src/cardano/block.rs
@@ -1,0 +1,51 @@
+use cardano_sdk::chain::{
+    AnyCbor, BlockAlonzo, BlockShelley, Header, HeaderVasil, MetadataSet, TransactionBodies,
+    TxIndexes,
+};
+use cbored::{CborRepr, DecodeError};
+
+#[derive(Clone, Debug, CborRepr, PartialEq, Eq)]
+#[cborrepr(structure = "array")]
+pub struct BlockVasil {
+    pub header: HeaderVasil,
+    pub tx_bodies: TransactionBodies,
+    pub tx_witnesses: AnyCbor,
+    pub metadata_set: MetadataSet,
+    pub invalid_tx: TxIndexes,
+}
+
+#[derive(Debug, Clone, CborRepr, PartialEq, Eq)]
+#[cborrepr(enumtype = "tagvariant", variant_starts_at = 2)]
+pub enum Block {
+    Shelley(BlockShelley),
+    Block3(BlockShelley),
+    Block4(BlockShelley),
+    Alonzo(BlockAlonzo),
+    Vasil(BlockVasil),
+}
+
+impl Block {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
+        cbored::decode_from_bytes(bytes)
+    }
+
+    pub fn header(&self) -> Header {
+        match self {
+            Block::Shelley(blk) => blk.header.clone().into(),
+            Block::Block3(blk) => blk.header.clone().into(),
+            Block::Block4(blk) => blk.header.clone().into(),
+            Block::Alonzo(blk) => blk.header.clone().into(),
+            Block::Vasil(blk) => blk.header.clone().into(),
+        }
+    }
+
+    pub fn tx_bodies(&self) -> &TransactionBodies {
+        match self {
+            Block::Shelley(blk) => &blk.tx_bodies,
+            Block::Block3(blk) => &blk.tx_bodies,
+            Block::Block4(blk) => &blk.tx_bodies,
+            Block::Alonzo(blk) => &blk.tx_bodies,
+            Block::Vasil(blk) => &blk.tx_bodies,
+        }
+    }
+}

--- a/blockchain-source/src/cardano/event.rs
+++ b/blockchain-source/src/cardano/event.rs
@@ -104,7 +104,7 @@ impl<Tip> GetNextFrom for CardanoNetworkEvent<BlockEvent, Tip> {
 
 impl BlockEvent {
     pub(crate) fn from_serialized_block(raw_block: &[u8]) -> anyhow::Result<Self> {
-        let block: anyhow::Result<cardano_sdk::chain::Block> =
+        let block: anyhow::Result<crate::cardano::block::Block> =
             cbored::decode_from_bytes(raw_block).context("failed to deserialize block");
 
         if let Ok(block) = block {

--- a/blockchain-source/src/cardano/mod.rs
+++ b/blockchain-source/src/cardano/mod.rs
@@ -1,3 +1,4 @@
+pub mod block;
 mod byron;
 mod configuration;
 mod event;


### PR DESCRIPTION
BlockVasil: skip deserialization of tx_witnesses field

There is a problem with the deserialization of the Redeemer type, but
since we don't really need the witnesses, we can avoid it by just
skipping the field.

Unfortunately, this requires duplicating some code from the sdk.

TODO: this probably needs to be done for the other block types too, but I'm not aware of those failing