### PR TITLE
fix read_write_memory quickcheck test

### DIFF
--- a/fraos/src/database.rs
+++ b/fraos/src/database.rs
@@ -168,7 +168,7 @@ mod tests {
             .map(|data| data.as_ref())
             .collect();
 
-        if data1.is_empty() || data2.is_empty() {
+        if records1.is_empty() || records2.is_empty() {
             return;
         }
 


### PR DESCRIPTION
this should fix the CI failure in: https://github.com/dcSpark/dcspark-core/pull/24

Although I think the proper fix may be to use `TestResult::discard` from quickcheck, though, but I'm not super familiar with these tests.