### PR TITLE
critical_error!: use fully-qualified path for the type

### DIFF
--- a/blockchain-source/src/cardano/mod.rs
+++ b/blockchain-source/src/cardano/mod.rs
@@ -15,7 +15,6 @@ pub use cardano_sdk::protocol::Tip;
 use cardano_sdk::protocol::Version;
 pub use configuration::{ChainInfo, NetworkConfiguration};
 use dcspark_core::critical_error;
-use dcspark_core::error::CriticalError;
 pub use point::*;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::Duration;

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -13,7 +13,7 @@ impl std::fmt::Display for CriticalError {
 #[macro_export]
 macro_rules! critical_error {
     () => {
-        CriticalError {
+        $crate::error::CriticalError {
             line: line!(),
             file: file!(),
         }


### PR DESCRIPTION
without this, `CriticalError` needs to be imported wherever the macro is used