### PR TITLE
remove print_profile_on_drop on sled initialization

### DIFF
--- a/multiverse/src/lib.rs
+++ b/multiverse/src/lib.rs
@@ -315,10 +315,7 @@ where
     where
         P: AsRef<Path>,
     {
-        let db = sled::Config::new()
-            .path(&path)
-            .print_profile_on_drop(false)
-            .open()?;
+        let db = sled::Config::new().path(&path).open()?;
 
         Self::load_from(db, domain, store_from)
     }


### PR DESCRIPTION
Newest sled release still supports it, but it is already removed from `main` branch. Introducing this PR here to keep things consistent with bridge code 
