### PR TITLE
bump bigdecimal to 0.4.2

### DIFF
--- a/deps/Cargo.toml
+++ b/deps/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bigdecimal = { version = "0.3.0" }
+bigdecimal = { version = "0.4.2" }
 serde_json = { version = "1.0" }


### PR DESCRIPTION
so that the big decimal visitor can be used in deps using 0.4