### PR TITLE
fix sancho startup config

### DIFF
--- a/blockchain-source/src/cardano/configuration.rs
+++ b/blockchain-source/src/cardano/configuration.rs
@@ -8,7 +8,7 @@ pub struct NetworkConfiguration {
     pub relay: (Cow<'static, str>, u16),
     pub from: Point,
     pub genesis_parent: BlockId,
-    pub genesis: BlockId,
+    pub genesis: Point,
     pub shelley_era_config: Era,
 }
 
@@ -26,9 +26,12 @@ impl NetworkConfiguration {
             genesis_parent: BlockId::new(
                 "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb",
             ),
-            genesis: BlockId::new(
-                "89d9b5a5b8ddc8d7e5a6795e9774d97faf1efea59b2caf7eaf9f8c5b32059df4",
-            ),
+            genesis: Point::BlockHeader {
+                hash: BlockId::new(
+                    "89d9b5a5b8ddc8d7e5a6795e9774d97faf1efea59b2caf7eaf9f8c5b32059df4",
+                ),
+                slot_nb: SlotNumber::new(0),
+            },
             shelley_era_config: Era::SHELLEY_MAINNET,
         }
     }
@@ -49,9 +52,12 @@ impl NetworkConfiguration {
             genesis_parent: BlockId::new(
                 "96fceff972c2c06bd3bb5243c39215333be6d56aaf4823073dca31afe5038471",
             ),
-            genesis: BlockId::new(
-                "8f8602837f7c6f8b8867dd1cbc1842cf51a27eaed2c70ef48325d00f8efb320f",
-            ),
+            genesis: Point::BlockHeader {
+                hash: BlockId::new(
+                    "8f8602837f7c6f8b8867dd1cbc1842cf51a27eaed2c70ef48325d00f8efb320f",
+                ),
+                slot_nb: SlotNumber::new(0),
+            },
             shelley_era_config: Era::SHELLEY_TESTNET,
         }
     }
@@ -69,9 +75,12 @@ impl NetworkConfiguration {
             genesis_parent: BlockId::new(
                 "d4b8de7a11d929a323373cbab6c1a9bdc931beffff11db111cf9d57356ee1937",
             ),
-            genesis: BlockId::new(
-                "9ad7ff320c9cf74e0f5ee78d22a85ce42bb0a487d0506bf60cfb5a91ea4497d2",
-            ),
+            genesis: Point::BlockHeader {
+                hash: BlockId::new(
+                    "9ad7ff320c9cf74e0f5ee78d22a85ce42bb0a487d0506bf60cfb5a91ea4497d2",
+                ),
+                slot_nb: SlotNumber::new(0),
+            },
             shelley_era_config: Era::SHELLEY_PREPROD,
         }
     }
@@ -89,9 +98,12 @@ impl NetworkConfiguration {
             genesis_parent: BlockId::new(
                 "72593f260b66f26bef4fc50b38a8f24d3d3633ad2e854eaf73039eb9402706f1",
             ),
-            genesis: BlockId::new(
-                "268ae601af8f9214804735910a3301881fbe0eec9936db7d1fb9fc39e93d1e37",
-            ),
+            genesis: Point::BlockHeader {
+                hash: BlockId::new(
+                    "268ae601af8f9214804735910a3301881fbe0eec9936db7d1fb9fc39e93d1e37",
+                ),
+                slot_nb: SlotNumber::new(0),
+            },
             shelley_era_config: Era::SHELLEY_PREVIEW,
         }
     }
@@ -113,11 +125,14 @@ impl NetworkConfiguration {
                 ),
             },
             genesis_parent: BlockId::new(
-                "6a7d97aae2a65ca790fd14802808b7fce00a3362bd7b21c4ed4ccb4296783b98",
+                "785eb88427e136378a15b0a152a8bfbeec7a611529ccda29c43a1e60ffb48eaa",
             ),
-            genesis: BlockId::new(
-                "6a7d97aae2a65ca790fd14802808b7fce00a3362bd7b21c4ed4ccb4296783b98",
-            ),
+            genesis: Point::BlockHeader {
+                hash: BlockId::new(
+                    "6a7d97aae2a65ca790fd14802808b7fce00a3362bd7b21c4ed4ccb4296783b98",
+                ),
+                slot_nb: SlotNumber::new(20),
+            },
             shelley_era_config: Era::SHELLEY_SANCHO,
         }
     }

--- a/blockchain-source/src/cardano/mod.rs
+++ b/blockchain-source/src/cardano/mod.rs
@@ -205,10 +205,7 @@ async fn request_handler(
                 slot_nb: 0.into(),
                 hash: network_config.genesis_parent.clone(),
             }] {
-            vec![Point::BlockHeader {
-                hash: network_config.genesis.clone(),
-                slot_nb: 0.into(),
-            }]
+            vec![network_config.genesis.clone()]
         } else {
             from
         };


### PR DESCRIPTION
Unlike the other networks, the first block of sancho has a non zero slot, so the workaround for the sync from scratch doesn't work. There is also the problem of this block being ignored right now.